### PR TITLE
keep nested paths

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -540,7 +540,7 @@
         <li><a href="#tests">Test Report</a></li>
         <li><a href="#coverage">Coverage Report</a></li>
         <li>
-            <span class="cov high">86.84</span>
+            <span class="cov high">88.16</span>
             <a href="#lib/index.js"><span class="dirname">lib/</span><span class="basename">index.js</span></a>
         </li>
         <li><a href="#linting">Linting Report</a></li>
@@ -550,8 +550,8 @@
       <div class="stats high">
           <div class="failures">0</div>
           <div class="skipped">0</div>
-          <div class="test-count">3</div>
-          <div class="duration">21</div>
+          <div class="test-count">4</div>
+          <div class="duration">28</div>
       </div>
       <div id="filters">
           <input type="checkbox" checked="" onchange="filter(this)" value="success" id="show-success"><label for="show-success">Show Success</label></input>
@@ -573,18 +573,25 @@
               <td class="test-title">node-rev generates a manifest without hashing
                   
               </td>
-              <td class="test-duration">13</td>
+              <td class="test-duration">14</td>
           </tr>
           <tr class="show node-rev success">
               <td class="test-id">2</td>
               <td class="test-title">node-rev generates a manifest with hashing
                   
               </td>
-              <td class="test-duration">3</td>
+              <td class="test-duration">5</td>
           </tr>
           <tr class="show node-rev success">
               <td class="test-id">3</td>
               <td class="test-title">node-rev takes multiple glob patterns separated by commas
+                  
+              </td>
+              <td class="test-duration">4</td>
+          </tr>
+          <tr class="show node-rev success">
+              <td class="test-id">4</td>
+              <td class="test-title">node-rev keeps relative paths even if deeper than one
                   
               </td>
               <td class="test-duration">2</td>
@@ -595,19 +602,19 @@
     </div>    <div id="coverage">
         <h1>Code Coverage Report</h1>
         <div class="stats high">
-            <div class="percentage">86.84%</div>
+            <div class="percentage">88.16%</div>
             <div class="sloc">76</div>
-            <div class="hits">66</div>
-            <div class="misses">10</div>
+            <div class="hits">67</div>
+            <div class="misses">9</div>
         </div>
         <div id="files">
             <div class="file">
                 <h2 id="lib/index.js">lib/index.js</h2>
                 <div class="stats high">
-                    <div class="percentage">86.84%</div>
+                    <div class="percentage">88.16%</div>
                     <div class="sloc">76</div>
-                    <div class="hits">66</div>
-                    <div class="misses">10</div>
+                    <div class="hits">67</div>
+                    <div class="misses">9</div>
                 </div>
                 <table>
                     <thead>
@@ -682,13 +689,13 @@
                         <tr class="hit">
                             <td class="line" data-tooltip>11</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  (0, _assert2.default)(options.files, &#x27;files property is required&#x27;);</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>12</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var filesPath &#x3D; options.files;</td>
                         </tr>
                             <tr class="chunks">
@@ -700,19 +707,19 @@
                         <tr class="hit">
                             <td class="line" data-tooltip>14</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var outputDest &#x3D; _path2.default.resolve(outputDir);</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>15</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var file &#x3D; options.file;</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>16</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var hash &#x3D; options.hash || false;</td>
                         </tr>
                         <tr class="hit">
@@ -736,13 +743,13 @@
                         <tr class="hit">
                             <td class="line" data-tooltip>20</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">      _fsExtra2.default.ensureFileSync(_path2.default.resolve(file));</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>21</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">      _fsExtra2.default.writeFileSync(_path2.default.resolve(file), JSON.stringify(manifest), &#x27;utf8&#x27;);</td>
                         </tr>
                         <tr class="hit">
@@ -778,19 +785,19 @@
                         <tr class="hit">
                             <td class="line" data-tooltip>27</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var filesPathParts &#x3D; filesPath.split(&#x27;,&#x27;);</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>28</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var files &#x3D; [];</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>29</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  filesPathParts.forEach(function (filePathPart) {</td>
                         </tr>
                         <tr class="hit">
@@ -814,401 +821,395 @@
                         <tr class="hit">
                             <td class="line" data-tooltip>33</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
-                            <td class="source">  console.log(files);</td>
-                        </tr>
-                        <tr class="hit">
-                            <td class="line" data-tooltip>34</td>
-                            <td class="lint empty"></td>
-                            <td class="hits" data-tooltip></td>
-                            <td class="source"></td>
-                        </tr>
-                        <tr class="hit">
-                            <td class="line" data-tooltip>35</td>
-                            <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">  var baseDir &#x3D; void 0;</td>
                         </tr>
                             <tr class="chunks">
-                                <td class="line" data-tooltip>36</td>
+                                <td class="line" data-tooltip>34</td>
                                 <td class="lint empty"></td>
                                 <td class="hits" data-tooltip></td>
                                 <td class="source"><div>  if (</div><div class="miss true" data-tooltip>files</div><div> &amp;&amp; files.length &#x3D;&#x3D;&#x3D; 1) {</div></td>
                             </tr>
+                            <tr class="miss">
+                                <td class="line" data-tooltip>35</td>
+                                <td class="lint empty"></td>
+                                <td class="hits" data-tooltip></td>
+                                <td class="source" data-tooltip>    baseDir &#x3D; files[0].split(&#x27;/&#x27;).slice(0, -1).join(&#x27;/&#x27;);</td>
+                            </tr>
+                        <tr class="hit">
+                            <td class="line" data-tooltip>36</td>
+                            <td class="lint empty"></td>
+                            <td class="hits" data-tooltip></td>
+                            <td class="source">  } else {</td>
+                        </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>37</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>2</td>
-                            <td class="source">    baseDir &#x3D; files[0].split(&#x27;/&#x27;).slice(0, -1).join(&#x27;/&#x27;);</td>
+                            <td class="hits" data-tooltip>4</td>
+                            <td class="source">    baseDir &#x3D; (0, _commondir2.default)(files);</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>38</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
-                            <td class="source">  } else {</td>
-                        </tr>
-                        <tr class="hit">
-                            <td class="line" data-tooltip>39</td>
-                            <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>1</td>
-                            <td class="source">    baseDir &#x3D; (0, _commondir2.default)(files);</td>
-                        </tr>
-                        <tr class="hit">
-                            <td class="line" data-tooltip>40</td>
-                            <td class="lint empty"></td>
-                            <td class="hits" data-tooltip></td>
                             <td class="source">  }</td>
                         </tr>
                             <tr class="chunks">
-                                <td class="line" data-tooltip>41</td>
+                                <td class="line" data-tooltip>39</td>
                                 <td class="lint empty"></td>
                                 <td class="hits" data-tooltip></td>
                                 <td class="source"><div>  if (</div><div class="miss true" data-tooltip>files</div><div> &amp;&amp; files.length) {</div></td>
                             </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>42</td>
+                            <td class="line" data-tooltip>40</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">    files.forEach(function (file) {</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>43</td>
+                            <td class="line" data-tooltip>41</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">      var parsedPath &#x3D; _path2.default.parse(file);</td>
                         </tr>
                         <tr class="hit">
+                            <td class="line" data-tooltip>42</td>
+                            <td class="lint empty"></td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      var filename &#x3D; parsedPath.base;</td>
+                        </tr>
+                        <tr class="hit">
+                            <td class="line" data-tooltip>43</td>
+                            <td class="lint empty"></td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      var dirParts &#x3D; parsedPath.dir.split(&#x27;/&#x27;);</td>
+                        </tr>
+                        <tr class="hit">
                             <td class="line" data-tooltip>44</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>5</td>
-                            <td class="source">      var filename &#x3D; parsedPath.base;</td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      var fileDirParts &#x3D; [];</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>45</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>5</td>
-                            <td class="source">      var dirParts &#x3D; parsedPath.dir.split(&#x27;/&#x27;);</td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      while (dirParts.join(&#x27;/&#x27;) !&#x3D;&#x3D; baseDir) {</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>46</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>5</td>
-                            <td class="source">      var fileDir &#x3D; &#x27;&#x27;;</td>
+                            <td class="hits" data-tooltip>10</td>
+                            <td class="source">        fileDirParts.unshift(dirParts.pop());</td>
                         </tr>
-                            <tr class="chunks">
-                                <td class="line" data-tooltip>47</td>
-                                <td class="lint empty"></td>
-                                <td class="hits" data-tooltip></td>
-                                <td class="source"><div>      if (</div><div class="miss false" data-tooltip>baseDir !&#x3D;&#x3D; parsedPath.dir</div><div>) {</div></td>
-                            </tr>
-                            <tr class="miss">
-                                <td class="line" data-tooltip>48</td>
-                                <td class="lint empty"></td>
-                                <td class="hits" data-tooltip></td>
-                                <td class="source" data-tooltip>        fileDir &#x3D; dirParts.pop();</td>
-                            </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>49</td>
+                            <td class="line" data-tooltip>47</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">      }</td>
                         </tr>
                         <tr class="hit">
+                            <td class="line" data-tooltip>48</td>
+                            <td class="lint empty"></td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      var fileDir &#x3D; fileDirParts.join(&#x27;/&#x27;);</td>
+                        </tr>
+                        <tr class="hit">
+                            <td class="line" data-tooltip>49</td>
+                            <td class="lint empty"></td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      var buffer &#x3D; _fsExtra2.default.readFileSync(file);</td>
+                        </tr>
+                        <tr class="hit">
                             <td class="line" data-tooltip>50</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>5</td>
-                            <td class="source">      var buffer &#x3D; _fsExtra2.default.readFileSync(file);</td>
+                            <td class="hits" data-tooltip>11</td>
+                            <td class="source">      if (hash) {</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>51</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>5</td>
-                            <td class="source">      if (hash) {</td>
+                            <td class="hits" data-tooltip>9</td>
+                            <td class="source">        var _hash &#x3D; (0, _revHash2.default)(buffer);</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>52</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>4</td>
-                            <td class="source">        var _hash &#x3D; (0, _revHash2.default)(buffer);</td>
+                            <td class="hits" data-tooltip>9</td>
+                            <td class="source">        var revdPath &#x3D; (0, _revPath2.default)(_path2.default.join(fileDir, filename), _hash);</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>53</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>4</td>
-                            <td class="source">        var revdPath &#x3D; (0, _revPath2.default)(_path2.default.join(fileDir, filename), _hash);</td>
+                            <td class="hits" data-tooltip>9</td>
+                            <td class="source">        manifest[_path2.default.join(fileDir, filename)] &#x3D; revdPath;</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>54</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>4</td>
-                            <td class="source">        manifest[_path2.default.join(fileDir, filename)] &#x3D; revdPath;</td>
+                            <td class="hits" data-tooltip>9</td>
+                            <td class="source">        _fsExtra2.default.ensureFileSync(_path2.default.join(outputDest, revdPath));</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>55</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>4</td>
-                            <td class="source">        _fsExtra2.default.ensureFileSync(_path2.default.join(outputDest, revdPath));</td>
-                        </tr>
-                        <tr class="hit">
-                            <td class="line" data-tooltip>56</td>
-                            <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>4</td>
+                            <td class="hits" data-tooltip>9</td>
                             <td class="source">        _fsExtra2.default.writeFileSync(_path2.default.join(outputDest, revdPath), buffer);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>57</td>
+                            <td class="line" data-tooltip>56</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">      } else {</td>
                         </tr>
                         <tr class="hit">
+                            <td class="line" data-tooltip>57</td>
+                            <td class="lint empty"></td>
+                            <td class="hits" data-tooltip>2</td>
+                            <td class="source">        manifest[_path2.default.join(fileDir, filename)] &#x3D; _path2.default.join(fileDir, filename);</td>
+                        </tr>
+                        <tr class="hit">
                             <td class="line" data-tooltip>58</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>1</td>
-                            <td class="source">        manifest[_path2.default.join(fileDir, filename)] &#x3D; _path2.default.join(fileDir, filename);</td>
+                            <td class="hits" data-tooltip>2</td>
+                            <td class="source">        _fsExtra2.default.ensureFileSync(_path2.default.join(outputDest, _path2.default.join(fileDir, filename)));</td>
                         </tr>
                         <tr class="hit">
                             <td class="line" data-tooltip>59</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>1</td>
-                            <td class="source">        _fsExtra2.default.ensureFileSync(_path2.default.join(outputDest, _path2.default.join(fileDir, filename)));</td>
-                        </tr>
-                        <tr class="hit">
-                            <td class="line" data-tooltip>60</td>
-                            <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>1</td>
+                            <td class="hits" data-tooltip>2</td>
                             <td class="source">        _fsExtra2.default.writeFileSync(_path2.default.join(outputDest, _path2.default.join(fileDir, filename)), buffer);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>61</td>
+                            <td class="line" data-tooltip>60</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">      }</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>62</td>
+                            <td class="line" data-tooltip>61</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">    });</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>63</td>
+                            <td class="line" data-tooltip>62</td>
                             <td class="lint empty"></td>
-                            <td class="hits" data-tooltip>3</td>
+                            <td class="hits" data-tooltip>4</td>
                             <td class="source">    writeManifest(manifest);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>64</td>
+                            <td class="line" data-tooltip>63</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">  } else {</td>
                         </tr>
                             <tr class="miss">
-                                <td class="line" data-tooltip>65</td>
+                                <td class="line" data-tooltip>64</td>
                                 <td class="lint empty"></td>
                                 <td class="hits" data-tooltip></td>
                                 <td class="source" data-tooltip>    console.warn(&#x27;No files found matching &#x27; + _path2.default.resolve(filesPath));</td>
                             </tr>
                             <tr class="miss">
-                                <td class="line" data-tooltip>66</td>
+                                <td class="line" data-tooltip>65</td>
                                 <td class="lint empty"></td>
                                 <td class="hits" data-tooltip></td>
                                 <td class="source" data-tooltip>    writeManifest({});</td>
                             </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>67</td>
+                            <td class="line" data-tooltip>66</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">  }</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>68</td>
+                            <td class="line" data-tooltip>67</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source">};</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>69</td>
+                            <td class="line" data-tooltip>68</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>70</td>
+                            <td class="line" data-tooltip>69</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _revHash &#x3D; require(&#x27;rev-hash&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>71</td>
+                            <td class="line" data-tooltip>70</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>72</td>
+                            <td class="line" data-tooltip>71</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _revHash2 &#x3D; _interopRequireDefault(_revHash);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>73</td>
+                            <td class="line" data-tooltip>72</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>74</td>
+                            <td class="line" data-tooltip>73</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _revPath &#x3D; require(&#x27;rev-path&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>75</td>
+                            <td class="line" data-tooltip>74</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>76</td>
+                            <td class="line" data-tooltip>75</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _revPath2 &#x3D; _interopRequireDefault(_revPath);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>77</td>
+                            <td class="line" data-tooltip>76</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>78</td>
+                            <td class="line" data-tooltip>77</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _path &#x3D; require(&#x27;path&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>79</td>
+                            <td class="line" data-tooltip>78</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>80</td>
+                            <td class="line" data-tooltip>79</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _path2 &#x3D; _interopRequireDefault(_path);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>81</td>
+                            <td class="line" data-tooltip>80</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>82</td>
+                            <td class="line" data-tooltip>81</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _fsExtra &#x3D; require(&#x27;fs-extra&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>83</td>
+                            <td class="line" data-tooltip>82</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>84</td>
+                            <td class="line" data-tooltip>83</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _fsExtra2 &#x3D; _interopRequireDefault(_fsExtra);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>85</td>
+                            <td class="line" data-tooltip>84</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>86</td>
+                            <td class="line" data-tooltip>85</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _glob &#x3D; require(&#x27;glob&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>87</td>
+                            <td class="line" data-tooltip>86</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>88</td>
+                            <td class="line" data-tooltip>87</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _glob2 &#x3D; _interopRequireDefault(_glob);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>89</td>
+                            <td class="line" data-tooltip>88</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>90</td>
+                            <td class="line" data-tooltip>89</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _commondir &#x3D; require(&#x27;commondir&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>91</td>
+                            <td class="line" data-tooltip>90</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>92</td>
+                            <td class="line" data-tooltip>91</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _commondir2 &#x3D; _interopRequireDefault(_commondir);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>93</td>
+                            <td class="line" data-tooltip>92</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>94</td>
+                            <td class="line" data-tooltip>93</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _assert &#x3D; require(&#x27;assert&#x27;);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>95</td>
+                            <td class="line" data-tooltip>94</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>96</td>
+                            <td class="line" data-tooltip>95</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip>1</td>
                             <td class="source">var _assert2 &#x3D; _interopRequireDefault(_assert);</td>
                         </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>97</td>
+                            <td class="line" data-tooltip>96</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>
                         </tr>
                             <tr class="chunks">
-                                <td class="line" data-tooltip>98</td>
+                                <td class="line" data-tooltip>97</td>
                                 <td class="lint empty"></td>
                                 <td class="hits" data-tooltip></td>
                                 <td class="source"><div>function _interopRequireDefault(obj) { return </div><div class="miss true" data-tooltip>obj</div><div> &amp;&amp; obj.__esModule ? </div><div class="miss never" data-tooltip>obj</div><div> : { default: obj }; }</div></td>
                             </tr>
                         <tr class="hit">
-                            <td class="line" data-tooltip>99</td>
+                            <td class="line" data-tooltip>98</td>
                             <td class="lint empty"></td>
                             <td class="hits" data-tooltip></td>
                             <td class="source"></td>

--- a/src/index.es6
+++ b/src/index.es6
@@ -45,9 +45,9 @@ export default function(options) {
       const dirParts = parsedPath.dir.split('/')
       let fileDirParts = []
       while(dirParts.join('/') !== baseDir) {
-        fileDirParts.unshift(dirParts.pop());
+        fileDirParts.unshift(dirParts.pop())
       }
-      let fileDir = fileDirParts.join('/');
+      let fileDir = fileDirParts.join('/')
       const buffer = fs.readFileSync(file)
       if (hash) {
         const hash = revHash(buffer)

--- a/src/index.es6
+++ b/src/index.es6
@@ -43,10 +43,11 @@ export default function(options) {
       const parsedPath = path.parse(file)
       const filename = parsedPath.base
       const dirParts = parsedPath.dir.split('/')
-      let fileDir = ''
-      if (baseDir !== parsedPath.dir) {
-        fileDir = dirParts.pop()
+      let fileDirParts = []
+      while(dirParts.join('/') !== baseDir) {
+        fileDirParts.unshift(dirParts.pop());
       }
+      let fileDir = fileDirParts.join('/');
       const buffer = fs.readFileSync(file)
       if (hash) {
         const hash = revHash(buffer)

--- a/test/node-rev.es6
+++ b/test/node-rev.es6
@@ -44,4 +44,17 @@ lab.experiment('node-rev', function() {
     expect(manifest['test.css']).to.startWith('test-')
     done()
   })
+  lab.test('keeps nested paths even if deeper than one', function(done) {
+    nodeRev({
+      files: 'fixtures/**/*.css',//glob to files you want in the manifest
+      outputDir: 'tmp/',//where you want the files to be output that are part of the manifest
+      file: 'tmp/assets.json',//optional, allows you to specify location of manifest file and name it, default is root of the project
+      hash: true//if you are in dev mode, you can set this to false to just have it create the manifest with the same filenames
+    })
+    const file = fs.readFileSync('./tmp/assets.json', 'utf8')
+    const manifest = JSON.parse(file)
+    expect(manifest['first-dir/second-dir/another.css']).to.startWith('first-dir/second-dir/another-')
+    expect(fs.existsSync('./tmp/first-dir/second-dir/another.css')).to.equal(true);
+    done()
+  })
 })


### PR DESCRIPTION
Currently only one level of nesting directories is preserved. If the file is nested deeper in some directories, only the last directory is used as target.

This PR ads a test for the nesting and fixes the issue.

Would really love to see this pulled in, as it breaks my asset pipeline :-)
